### PR TITLE
Ensure that the footer stays pinned to the bottom

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,12 +6,15 @@
     <%= csp_meta_tag %>
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <style>html { height: 100%; width: 100% }</style>
   </head>
 
-  <body>
+  <body class="flex flex-col flex-nowrap h-full w-full">
     <%= render "/@shared/header" %>
     <%= render "/@shared/flash" if flash.present? %>
-    <%= yield %>
+    <div class="flex-grow">
+      <%= yield %>
+    </div>
     <%= render "/@shared/footer" %>
   </body>
 </html>


### PR DESCRIPTION
This will turn this:
<img width="941" alt="Screenshot 2020-08-04 18 45 22" src="https://user-images.githubusercontent.com/5077225/89321336-23542b80-d683-11ea-8f50-35b44fce4911.png">

into this (minus the scrollbar, which is a side-effect of some extra changes I was experimenting with):
<img width="942" alt="Screenshot 2020-08-04 18 44 51" src="https://user-images.githubusercontent.com/5077225/89321349-264f1c00-d683-11ea-8fc8-9eb8f69cb528.png">
